### PR TITLE
This Pull Request closes #131, closes #99, and closes #139 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,10 +8,9 @@ class ApplicationController < ActionController::Base
   before_action :set_raven_context
   after_action  :set_access_control_headers
   after_action  :set_extra_headers
+  # full: true means that the string searched will look for the match anywhere in the "email" string, and not just the beginning
   autocomplete :university, :name, full: true
   autocomplete :major, :name, full: true
-  # allows autocomplete to work on the email field in user and creates a route through pages,
-  # :full => true means that the string searched will look for the match anywhere in the "email" string, and not just the beginning
   autocomplete :user, :email, full: true
 
   def set_access_control_headers

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,9 @@ class ApplicationController < ActionController::Base
   after_action  :set_extra_headers
   autocomplete :university, :name, full: true
   autocomplete :major, :name, full: true
+  # allows autocomplete to work on the email field in user and creates a route through pages,
+  # :full => true means that the string searched will look for the match anywhere in the "email" string, and not just the beginning
+  autocomplete :user, :email, full: true
 
   def set_access_control_headers
     headers['Access-Control-Allow-Origin'] = '*'

--- a/app/controllers/hardware_checkouts_controller.rb
+++ b/app/controllers/hardware_checkouts_controller.rb
@@ -1,6 +1,5 @@
 class HardwareCheckoutsController < ApplicationController
   before_action :set_hardware_checkout, only: [:destroy]
-  autocomplete :user, :email, :full => true
 
   def create
     # Create the checkout from params

--- a/app/controllers/hardware_items_controller.rb
+++ b/app/controllers/hardware_items_controller.rb
@@ -3,7 +3,6 @@ class HardwareItemsController < ApplicationController
   before_action :check_permissions, except: [:search, :index]
   before_action :check_attendee_slack, only: [:search, :index]
   before_action -> { is_feature_enabled($Hardware) }
-  autocomplete :user, :email, :full => true
 
   def search
     if params[:search].present?

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,9 +2,6 @@ class PagesController < ApplicationController
   before_action :check_permissions, only: [:add_permissions, :remove_permissions, :admin]
   before_action -> { is_feature_enabled($CheckIn) }, only: :check_in
   before_action :check_organizer_permissions, only: :check_in
-  # allows autocomplete to work on the email field in user and creates a route through pages,
-  # :full => true means that the string searched will look for the match anywhere in the "email" string, and not just the beginning
-  autocomplete :user, :email, :full => true
 
   def index
 
@@ -154,7 +151,7 @@ class PagesController < ApplicationController
 
   def remove_permissions
     @user = User.find(params[:format])
-    if User.where(user_type: "admin").length == 1
+    if @user.is_admin? and User.where(user_type: "admin").length == 1 
       redirect_to admin_path, alert: "Unable to remove permissions. There must be at least 1 administrator."
     else
       @user.user_type = 'attendee'

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -32,8 +32,12 @@ module PagesHelper
     controller?("events")
   end
 
-  def is_projects_active?
-      controller?("projects")
+  def is_projects_view_active?
+      controller?("projects") and (action?("public") or action?("show") or action?("search") or action?("index"))
+  end
+
+  def is_projects_create_active?
+    controller?("projects") and not (action?("public") or action?("show") or action?("search") or action?("index"))
   end
 
   def is_prizes_active?

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -14,7 +14,7 @@
             <div class="card-body">
               <%= form_tag event_check_in_to_event_path(@event.id), method: :post, class:'col-lg-12' do%>
                   <div class="input-group">
-                    <%= text_field_tag :email,'', class: 'form-control', placeholder: 'Scan QR Code or Type email', :autofocus => true, data: {autocomplete: autocomplete_user_email_hardware_checkouts_path}, 'min-length' => 1%>
+                    <%= text_field_tag :email,'', class: 'form-control', placeholder: 'Scan QR Code or Type email', :autofocus => true, data: {autocomplete: autocomplete_user_email_pages_path}, 'min-length' => 1%>
                     <span class="input-group-btn">
                         <%= submit_tag 'Check In', class: 'btn btn-primary' %>
                       </span>

--- a/app/views/pages/check_in.html.erb
+++ b/app/views/pages/check_in.html.erb
@@ -35,7 +35,7 @@
   <div class="card-body">
     <%= form_tag check_in_path, method: :get, class:'col-lg-12' do%>
         <div class="input-group">
-          <%= text_field_tag :email,'', class: 'form-control', placeholder: 'Scan QR Code or Type email', :autofocus => true, :onfocus => 'this.select()', :onmouseup => 'return false', data: {autocomplete: autocomplete_user_email_hardware_checkouts_path}, 'min-length' => 1%>
+          <%= text_field_tag :email,'', class: 'form-control', placeholder: 'Scan QR Code or Type email', :autofocus => true, :onfocus => 'this.select()', :onmouseup => 'return false', data: {autocomplete: autocomplete_user_email_pages_path}, 'min-length' => 1%>
           <span class="input-group-btn">
               <%= submit_tag 'Check In', class: 'btn btn-primary' %>
             </span>

--- a/app/views/projects/project_submit_info.html.erb
+++ b/app/views/projects/project_submit_info.html.erb
@@ -20,7 +20,7 @@
 
   <div class="card-body o-auto">
   <% if has_access_to_projects? %>
-      <%= link_to new_project_path, class: "nav-link #{'active' if is_projects_active?}" do %>
+      <%= link_to new_project_path, class: "nav-link #{'active' if is_projects_create_active?}" do %>
         <p class="btn btn-dark"> Create New Project</p>
       <% end %>
   <% end %>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -107,20 +107,20 @@
             <% if current_user.is_attendee?%>
               <% if HackumassWeb::Application::PROJECTS_PUBLIC %>
                 <li class="nav-item">
-                  <%= link_to projects_path, class: "nav-link #{'active' if is_projects_active?}" do %>
+                  <%= link_to projects_path, class: "nav-link #{'active' if is_projects_view_active?}" do %>
                     <i class="fe fe-layers"></i> Projects</a>
                   <% end %>
                 </li>
               <% end %>
               <li class="nav-item">
-                <%= link_to project_submit_info_path, class: "nav-link #{'active' if is_projects_active? and not HackumassWeb::Application::PROJECTS_PUBLIC}" do %>
+                <%= link_to project_submit_info_path, class: "nav-link #{'active' if is_projects_create_active?}" do %>
                   <i class="fe fe-layers"></i> My Project</a>
                 <% end %>
               </li>
 
             <% else %>
               <li class="nav-item">
-                <%= link_to projects_path, class: "nav-link #{'active' if is_projects_active?}" do %>
+                <%= link_to projects_path, class: "nav-link #{'active' if is_projects_view_active?}" do %>
                   <i class="fe fe-layers"></i> Projects</a>
                 <% end %>
               </li>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -9,7 +9,7 @@
           <a href="#" class="nav-link pr-0 leading-none" data-toggle="dropdown">
             <span class="avatar" style="background-image: url('https://d1mpvgh3wz53k.cloudfront.net/Content/img/empty-user-photo.png')"></span>
             <span class="ml-2 d-none d-lg-block">
-              <span class="text-default"><%= current_user.full_name.titleize%></span>
+              <span class="text-default"><%= current_user.full_name.camelcase%></span>
               <small class="text-muted d-block mt-1"><%= current_user.user_type.capitalize %></small>
             </span>
           </a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
       get 'change_pass', to: 'users#go_to_forgot'
     end
 
-  #Authentication Routes End
+  # Authentication Routes End
 
 
   # Event Application Routes Start
@@ -48,12 +48,9 @@ Rails.application.routes.draw do
 
   # Event Application Routes End
 
+
   resources :custom_rsvps, except: [:destroy] do
-
   end
-
-
-
 
 
   # Mentorship Request Routes Start
@@ -68,10 +65,7 @@ Rails.application.routes.draw do
       end
     end
 
-
-
   # Mentorship Request Routes End
-
 
 
   # Events Routes Start
@@ -82,6 +76,7 @@ Rails.application.routes.draw do
       post 'remove_user' => 'events#remove_user'
       post 'check_in_to_event' => 'events#check_in'
     end 
+
   # Events Routes End
 
 
@@ -121,6 +116,9 @@ Rails.application.routes.draw do
 
   # Pages Routes End
 
+
+  # Projects Routes Start
+
     resources :projects do
       get 'team' => 'projects#team', :as => :team
       post 'add_team_member' => 'projects#add_team_member', :as => :add_team_member
@@ -133,10 +131,18 @@ Rails.application.routes.draw do
 
     get 'projects/new/project_submit_info' => 'projects#project_submit_info', :as => :project_submit_info
 
+  # Projects Routes End
+
+
   # Hardware Routes Start
 
     # Allow autocomplete on hardware checkout page
     resources :hardware_checkouts, only: [:create, :destroy] do
+      get :autocomplete_user_email, :on => :collection
+    end
+
+    # Allow autocomplete on user email for all checked out items
+    resources :hardware_items, only: [:all_checked_out] do
       get :autocomplete_user_email, :on => :collection
     end
 
@@ -151,31 +157,36 @@ Rails.application.routes.draw do
       end
     end
 
-    # Allow autocomplete on user email for all checked out items
-    resources :hardware_items, only: [:all_checked_out] do
-      get :autocomplete_user_email, :on => :collection
-    end
-
   # Hardware Routes End
 
-  # Email Routes Begin
+
+  # Email Routes Start
+
     resources :emails do
       get 'send' => 'emails#send_email'
     end
+
   # Email Routes End
 
+
   # Feature Flag Routes Start
-   resources :feature_flags, except: [:create, :destroy, :edit, :show] do
-     collection do
-       post 'enable'
-       post 'disable'
-     end
-   end
+
+    resources :feature_flags, except: [:create, :destroy, :edit, :show] do
+      collection do
+        post 'enable'
+        post 'disable'
+      end
+    end
+
   # Feature Flag Routes End
 
-  # Judging Routes Begin
-  get 'judgings' => 'judging#index'
-  post 'generateforms' => 'judging#generateforms'
-  get "#{Rails.root}/public/judging/judging.pdf", :to => redirect("/judging/judging.pdf?#{Time.now.to_i}")
+
+  # Judging Routes Start
+
+    get 'judgings' => 'judging#index'
+    post 'generateforms' => 'judging#generateforms'
+    get "#{Rails.root}/public/judging/judging.pdf", :to => redirect("/judging/judging.pdf?#{Time.now.to_i}")
+
   # Judging Routes End
+
 end


### PR DESCRIPTION
This pull request deals with some bugs that have been reported and one that hasn't

- Issue #131 - Fixed by adding the active page flags to the page_helper controller
- Issue #99 - Fixed by changing the formatting of the full_name variable of users (From tytilelizing the name to camelcasing it)
- Issue #139 - This was caused by jquery not working in older browsers. JqueryUI is the gem we use to have autofill in the search bars and most likely it was disabled during its use on the computers at the hackathon. I cleaned the routing for it and formatted the config/routes.rb file a bit. I tested the autofill on numerous browsers and it works, but I can look into a solution for older browsers if needed.

Also fixed a bug in permissions where admins cannot remove permissions from organizers/mentors when there is one admin (Line 154 in pages_controller.rb)
