### PR TITLE
Implements feature flag sorting, closes #173

### DIFF
--- a/app/controllers/feature_flags_controller.rb
+++ b/app/controllers/feature_flags_controller.rb
@@ -64,7 +64,7 @@ class FeatureFlagsController < ApplicationController
 
     # Check parameters to ensure only whitelisted ones are able to be passed through.
     def feature_flag_params
-      params.require(:feature_flag).permit(:name, :value)
+      params.require(:feature_flag).permit(:name, :value, :description)
     end
 
     def check_permissions

--- a/app/views/feature_flags/_feature_flag.erb
+++ b/app/views/feature_flags/_feature_flag.erb
@@ -1,0 +1,29 @@
+
+<tr onMouseOver="$('#description').html('<%= feature_flag.description %>')" 
+    onMouseOut="$('#description').html(' Hover over flag for more ')">
+    <td>
+        <% if feature_flag.value == true %>
+            <span class="stamp stamp-md bg-green">
+            <i class="fe fe-check"></i>
+            </span>
+        <% else %>
+            <span class="stamp stamp-md bg-red">
+            <i class="fe fe-alert-circle"></i>
+            </span>
+        <% end %>
+    </td>
+    <td style="vertical-align: middle"><%= feature_flag.display_name %></td>
+    <td align="right" style="vertical-align: middle">
+        <% if feature_flag.value == true%>
+        <%= button_to 'Disable',
+            {controller:'feature_flags', action: 'disable',
+            params: {flag: feature_flag}},
+            {class: 'btn btn-secondary btn-sm'} %>
+        <% else %>
+        <%= button_to 'Enable',
+            {controller:'feature_flags', action: 'enable',
+            params: {flag: feature_flag}},
+            {class: 'btn btn-secondary btn-sm'} %>
+        <% end %>
+    </td>
+</tr>

--- a/app/views/feature_flags/index.html.erb
+++ b/app/views/feature_flags/index.html.erb
@@ -1,45 +1,53 @@
 <div class="page-header">
   <h1 class="page-title">Feature Flags</h1>
+  <div>
+    <br/>
+    <h1 class="page-subtitle">Description: </h1> 
+    <p class="page-subtitle leading-tight" id="description" style="vertical-align: middle"> Hover over flag for more </p> 
+  </div>
 </div>
 
-<div class="col-lg-5">
-  <div class="card">
-    <div class="card-header">
-      <h4 class="card-title">Features</h4>
+<div class="row row-cards ">
+  <div class="col-lg-5">
+    <div class="card">
+      <div class="card-header">
+        <h4 class="card-title">Getting Started</h4>
+      </div>
+      <table class="table card-table">
+        <tbody>
+          <%= render "feature_flag", feature_flag: @feature_flags.where( display_name: 'Applications' ).first %>
+          <%= render "feature_flag", feature_flag: @feature_flags.where( display_name: 'Check-Ins' ).first %>
+        </tbody>
+      </table>
     </div>
-    <table class="table card-table">
-      <tbody>
-        <% @feature_flags.each do |feature_flag| %>
-        <tr>
-          <td>
-            <% if feature_flag.value == true%>
-            <span class="stamp stamp-md bg-green">
-              <i class="fe fe-check"></i>
-            </span>
-            <% else %>
-            <span class="stamp stamp-md bg-red">
-              <i class="fe fe-alert-circle"></i>
-            </span>
-            <% end %>
-          </td>
-          <td style="vertical-align: middle"><%= feature_flag.display_name %></td>
-          <td style="vertical-align: middle">
-            <% if feature_flag.value == true%>
-            <%= button_to 'Disable',
-              {controller:'feature_flags', action: 'disable',
-              params: {flag: feature_flag}},
-              {class: 'btn btn-secondary btn-sm'} %>
-            <% else %>
-              <%= button_to 'Enable',
-                {controller:'feature_flags', action: 'enable',
-                params: {flag: feature_flag}},
-                {class: 'btn btn-secondary btn-sm'} %>
-            <% end %>
-          </td>
-        </tr>
-        <% end %>
-      </tbody>
-    </table>
+
+    <div class="card">
+      <div class="card-header">
+        <h4 class="card-title">Let the hacking begin!</h4>
+      </div>
+      <table class="table card-table">
+        <tbody>
+          <%= render "feature_flag", feature_flag: @feature_flags.where( display_name: 'Schedule' ).first %>
+          <%= render "feature_flag", feature_flag: @feature_flags.where( display_name: 'Mentorship Requests' ).first %>
+          <%= render "feature_flag", feature_flag: @feature_flags.where( display_name: 'Hardware Requests' ).first %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="col-lg-5">
+    <div class="card">
+      <div class="card-header">
+        <h4 class="card-title">After Hacks</h4>
+      </div>
+      <table class="table card-table">
+        <tbody>
+          <%= render "feature_flag", feature_flag: @feature_flags.where( display_name: 'Prizes' ).first %>
+          <%= render "feature_flag", feature_flag: @feature_flags.where( display_name: 'Projects: Create' ).first %>
+          <%= render "feature_flag", feature_flag: @feature_flags.where( display_name: 'Projects: View' ).first %>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>
 

--- a/lib/tasks/feature_flags.rake
+++ b/lib/tasks/feature_flags.rake
@@ -4,16 +4,24 @@ namespace :feature_flags do
 
     feature_flag_names = ['event_applications', 'mentorship_requests', 'hardware', 'projects', 'project_submissions', 'check_in','prizes', 'events']
     display_names = { "event_applications" => "Applications", "mentorship_requests" => "Mentorship Requests", "hardware" => "Hardware Requests", "projects" => "Projects: View", "project_submissions" => "Projects: Create", "check_in" => "Check-Ins", "prizes" => "Prizes", "events" => "Schedule"}
+    description = { "event_applications" => "Enables hackers to start registering and applying to the hackathon", 
+      "mentorship_requests" => "Allows hackers to request mentor help", 
+      "hardware" => "Enables the ability for hackers to checkout hardware", 
+      "projects" => "Allows projects to be seen to the public", 
+      "project_submissions" => "Gives Hackers the ability to submit projects as a team", 
+      "check_in" => "Starts the hackathon by allowing volunteers the ability to check in hackers", 
+      "prizes" => "Allows Prizes to be created and displayed for all hackers to see", 
+      "events" => "Allows planning of events and shows the schedule to hackers"}
 
     feature_flag_names.each do |flag_name|
       unless FeatureFlag.where(name: flag_name).exists?
-        FeatureFlag.create(name: flag_name, value: false, display_name: display_names[flag_name])
+        FeatureFlag.create(name: flag_name, value: false, display_name: display_names[flag_name], description: description[flag_name])
         puts "Creating #{flag_name} feature flag."
       end
     end
 
     feature_flag_names.each do |flag_name|
-      FeatureFlag.where(name: flag_name).update_all(display_name: display_names[flag_name])
+      FeatureFlag.where(name: flag_name).update_all(display_name: display_names[flag_name], description: description[flag_name])
       puts "Updating #{flag_name} feature flag."
     end
 


### PR DESCRIPTION
closes #173 - This PR fixes the previous front-end implementation of feature flags, where before we blindly displayed the flags by the ordered they were entered in the database. Now it is implemented with a partial erb file that displays the different feature flags grouped together and has a basic description implementation.

Now the feature flags are sectioned and are chronologically ordered (to the best of my knowledge) and descriptions that can be edited are stored within its own rake file. I designed the descriptions of the flags to be subtle, so hovering over the flag will only change the subtitle of the page. The feature flags still work to the best of my knowledge and the descriptions/titles can be finalized once put into production. 

![image](https://user-images.githubusercontent.com/9933268/73046791-636b6380-3e41-11ea-8b9c-ad32f5087236.png)