### PR TITLE
Redeem Codes to Gain Permissions

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -183,6 +183,23 @@ class PagesController < ApplicationController
     redirect_to root_path
   end
 
+  # GET for redeem code page
+  def redeem_code
+    # Just renders page
+  end
+
+  # POST for submitting code
+  def use_code
+    if HackumassWeb::Application::CODES.key?(params[:code].downcase)  # If a valid code
+      new_role = HackumassWeb::Application::CODES[params[:code].downcase]
+      current_user.user_type = new_role
+      current_user.save
+      redirect_to index_path, notice: 'Successfully Redeemed Code!'
+    else
+      redirect_to redeem_code_path, alert: 'Error: Invalid code provided.'
+    end
+  end
+
   private
 
   # Only admin is allowed to be in admin pages

--- a/app/views/pages/redeem_code.html.erb
+++ b/app/views/pages/redeem_code.html.erb
@@ -1,0 +1,22 @@
+<div class="page-header">
+  <h1 class="page-title">Redeem a Code</h1>
+</div>
+
+<div class="row">
+    <div class="col-md-12 col-xl-12 justify-content-center">
+        <div class="card">
+            <div class="card-body">
+            <%= form_tag use_code_path, method: :post, class:'col-lg-12' do %>
+                <div class="row gutters-xs">
+                <div class="col">
+                    <%= text_field_tag :code, params[:code], class: 'form-control', placeholder: 'Code (Case Insensitive)', :autofocus => true %>
+                </div>
+                <span class="col-auto">
+                    <%= submit_tag 'Redeem Code', name: nil, class: 'btn btn-primary btn-raised' %>
+                </span>
+                </div>
+            <%end%>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -17,6 +17,9 @@
             <%= link_to destroy_user_session_path, method: :delete,  class: "dropdown-item" do %>
               <i class="dropdown-icon fe fe-log-out"></i> Sign out
             <% end %>
+            <%= link_to redeem_code_path,  class: "dropdown-item" do %>
+              <i class="dropdown-icon fe fe-credit-card"></i> Redeem Code
+            <% end %>
             <%= link_to edit_user_registration_path, class: 'dropdown-item' do %>
               <i class="dropdown-icon fe fe-settings"></i> Account Settings
             <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,8 +51,14 @@ module HackumassWeb
     HACKING_BEGINS_DATE = config["projects"]["hacking_begins"]
     HACKING_ENDS_DATE = config["projects"]["hacking_ends"]
     SLACK_MESSAGE_URL_PREFIX = config["slack"]["message_url_prefix"]
-    CODES = config["codes"] or {}
-    CODES.transform_keys!(&:downcase)  # Makes all hashes to lowercase
+
+    if config.key?('codes')
+      CODES = config["codes"]
+      CODES.transform_keys!(&:downcase)  # Makes all hashes to lowercase
+    else
+      CODES = {}
+    end
+
 
     if event_application_config
       EVENT_APPLICATION_CUSTOM_FIELDS = event_application_config["custom_fields"] or []

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,6 +51,8 @@ module HackumassWeb
     HACKING_BEGINS_DATE = config["projects"]["hacking_begins"]
     HACKING_ENDS_DATE = config["projects"]["hacking_ends"]
     SLACK_MESSAGE_URL_PREFIX = config["slack"]["message_url_prefix"]
+    CODES = config["codes"] or {}
+    CODES.transform_keys!(&:downcase)  # Makes all hashes to lowercase
 
     if event_application_config
       EVENT_APPLICATION_CUSTOM_FIELDS = event_application_config["custom_fields"] or []

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,8 @@ Rails.application.routes.draw do
     # Make our URLs prettier
     get 'index' => 'pages#index'
     get 'admin' => 'pages#admin'
+    get 'redeem_code' => 'pages#redeem_code'
+    post 'use_code' => 'pages#use_code'
 
     get 'check_in' => 'pages#check_in'
 


### PR DESCRIPTION
Previous on dashboard, all judges and mentors who registered had to have an organizer manually elevate the permissions on their account.

Now, you can define redeemable codes in hackathon-config to automatically grant permissions to a specific role when redeemed.