### PR TITLE
Change Application Mode Without Redeploying

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :auth_user
   before_action :set_raven_context
+  before_action :get_event_application_mode
   after_action  :set_access_control_headers
   after_action  :set_extra_headers
   # full: true means that the string searched will look for the match anywhere in the "email" string, and not just the beginning
@@ -17,6 +18,13 @@ class ApplicationController < ActionController::Base
   autocomplete :prize, :criteria, full: true
 
 
+  def get_event_application_mode
+    if !FeatureFlag.find_by(name: 'application_mode').nil?
+      @event_application_mode = FeatureFlag.find_by(name: 'application_mode').description
+    else
+      @event_application_mode = 'closed'
+    end
+  end
 
   def set_access_control_headers
     headers['Access-Control-Allow-Origin'] = '*'

--- a/app/controllers/event_applications_controller.rb
+++ b/app/controllers/event_applications_controller.rb
@@ -222,11 +222,6 @@ class EventApplicationsController < ApplicationController
   def set_event_application
     begin
       @application = EventApplication.find(params[:id])
-    rescue
-      flash[:warning] = 'Upppps looks like you went backwards or forward too much.'
-      redirect_to event_applications_path
-      return
-    end
   end
 
   def event_application_params

--- a/app/controllers/event_applications_controller.rb
+++ b/app/controllers/event_applications_controller.rb
@@ -86,11 +86,17 @@ class EventApplicationsController < ApplicationController
   end
 
   def new
+    if @event_application_mode == 'closed'
+      redirect_to index_path
+      flash[:error] = "Error: Event Applications are Currently Closed."
+      return
+    end
+
     @application = EventApplication.new
 
     if current_user.has_applied?
         redirect_to index_path
-        flash[:error] = "You have already created an application."
+        flash[:error] = "Error: You Have Already Created an Application."
     end
 
   end

--- a/app/controllers/event_applications_controller.rb
+++ b/app/controllers/event_applications_controller.rb
@@ -3,8 +3,8 @@ class EventApplicationsController < ApplicationController
   include EventApplicationsHelper
 
   before_action -> { is_feature_enabled($Applications) }
-  before_action :set_event_application, only: %i[show edit update destroy]
-  before_action :check_permissions, only: %i[index destroy status_updated]
+  before_action :set_event_application, only: [:show, :edit, :update, :destroy]
+  before_action :check_permissions, only: [:index, :destroy, :status_updated]
   autocomplete :university, :name, full: true
   autocomplete :major, :name, full: true
 
@@ -105,9 +105,9 @@ class EventApplicationsController < ApplicationController
     puts "cfields params: #{event_application_params['custom_fields']}"
     @application = EventApplication.new(event_application_params)
     @application.user = current_user
-    if HackumassWeb::Application::APPLICATIONS_MODE == 'open'
+    if @event_application_mode == 'open'
       @application.status = 'undecided'
-    elsif HackumassWeb::Application::APPLICATIONS_MODE == 'waitlist'
+    elsif @event_application_mode == 'waitlist'
       @application.status = 'waitlisted'
     else
       @application.status = 'denied'
@@ -217,11 +217,55 @@ class EventApplicationsController < ApplicationController
     redirect_to event_application_path(app)
   end
 
-   private
+  # GET route to show change event application mode page
+  def application_mode
+    if !FeatureFlag.find_by(name: 'application_mode').nil?
+      # Note: @event_application_mode is automatically updated in Application Controller
+      @current_mode = @event_application_mode
+    else
+      @current_mode = 'ERROR'
+    end
+  end
+
+  # POST route to set the current event application mode
+  def set_application_mode
+    if !current_user.is_admin?
+      redirect_to event_applications_path, alert: 'Error: You do not have permission to change event application modes.'
+    else
+      if !params[:mode].present?
+        redirect_to application_mode_event_applications_path, alert: 'Error: Invalid Parameters Provided (1) If you get this message, please try to refresh the page and try again.'
+      else
+        if params[:mode] == 'open'
+          @flag = FeatureFlag.find_by(name: 'application_mode')
+          @flag.description = 'open'
+          @flag.save
+          redirect_to application_mode_event_applications_path, notice: 'Successfully set application mode to open!'
+        elsif params[:mode] == 'waitlist'
+          @flag = FeatureFlag.find_by(name: 'application_mode')
+          @flag.description = 'waitlist'
+          @flag.save
+          redirect_to application_mode_event_applications_path, notice: 'Successfully set application mode to waitlist!'
+        elsif params[:mode] == 'closed'
+          @flag = FeatureFlag.find_by(name: 'application_mode')
+          @flag.description = 'closed'
+          @flag.save
+          redirect_to application_mode_event_applications_path, notice: 'Successfully closed event applications!'
+        else
+          redirect_to application_mode_event_applications_path, alert: 'Error: Invalid Parameters Provided (2). If you get this message, please try to refresh the page and try again.'
+        end
+      end
+    end
+  end
+
+  private
+
   # Use callbacks to share common setup or constraints between actions.
   def set_event_application
     begin
       @application = EventApplication.find(params[:id])
+    rescue
+      redirect_to event_applications_path, error: 'Error: Unable to load desired page. Please ensure the URL is valid and try again.'
+    end
   end
 
   def event_application_params

--- a/app/controllers/judging_controller.rb
+++ b/app/controllers/judging_controller.rb
@@ -27,7 +27,6 @@ class JudgingController < ApplicationController
           @projects = Project.where("prizes LIKE ?", "%#{params[:prize]}%")
         end
       else
-        puts "heeeeeeeeeeeeeeeeeeeeeeeeeeeeeellllllllllllllp"
         @projects = Project.left_outer_joins(:judgements => :user).distinct.where("first_name LIKE lower(?) OR last_name LIKE lower(?) OR title LIKE lower(?) OR table_id = ?",
         "%#{params[:search]}%", "%#{params[:search]}%", "%#{params[:search]}%", params[:search].match(/^(\d)+$/) ? params[:search].to_i : 99999)
       end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -90,7 +90,7 @@ module PagesHelper
   end
 
   def has_access_to_applying?
-    current_user.is_attendee? and check_feature_flag?($Applications)
+    current_user.is_attendee? and check_feature_flag?($Applications) and @event_application_mode != 'closed'
   end
 
   def has_access_to_judging?

--- a/app/views/event_applications/application_mode.html.erb
+++ b/app/views/event_applications/application_mode.html.erb
@@ -1,0 +1,61 @@
+<div class="page-header">
+  <h1 class="page-title">Event Applications Mode</h1>
+</div>
+
+<div class="row justify-content-center">
+    <div class="col-lg-12">
+        <div class="card">
+            <div class="card-header">
+                <h4 class="card-title">Current Event Application Mode</h4>
+            </div>
+            <div class="card-body">
+                <p class="h4">Current Application Mode:
+                    <% if @current_mode == 'open' %> 
+                        <span class="text-green"> <%= 'Open (New Applications Allowed)' %></span>
+                    <% elsif @current_mode == 'waitlist' %>
+                        <span class="text-orange"> <%= 'Waitlist (All Applicants Automatically Waitlisted)' %></span>
+                    <% elsif @current_mode == 'closed' %>
+                        <span class="text-red"> <%= 'Closed (No Applications May Be Submitted)' %></span>
+                    <% else %>
+                        <span class="text-blue"> <%= '[Error]: Please Contact Administrator' %></span>
+                    <% end %>       
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-lg-12">
+        <div class="card">
+            <div class="card-body">
+                
+            <table class="table">
+                <thead>
+                    <tr>
+                    <th scope="col">Mode</th>
+                    <th scope="col">Description</th>
+                    <th scope="col">Action</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <th scope="row">Open</th>
+                        <td class="w-50">In this mode, anyone can create accounts, submit applications to the event, and then have them collected for review by organizers. This should be enabled before the event to allow everyone to apply. </td>
+                        <td><%= link_to 'Open Applications', set_application_mode_event_applications_path(:mode => 'open'), class: 'btn btn-success', method: :post %></td>
+                    </tr>
+                    <tr>
+                        <th scope="row">Waitlist</th>
+                        <td class="w-50">In this mode, anyone can create accounts and submit applications to the event, but their applications will be automatically waitlisted. This should be enabled when you're done accepting applications before the event but don't want to reject all applicants automatically. </td>
+                        <td><%= link_to 'Waitlist Applications', set_application_mode_event_applications_path(:mode => 'waitlist'), class: 'btn btn-warning', method: :post %></td>                    
+                    </tr>
+                    <tr>
+                        <th scope="row">Open</th>
+                        <td>No applications can be submitted in this mode.</td>
+                        <td><%= link_to 'Close Applications', set_application_mode_event_applications_path(:mode => 'closed'), class: 'btn btn-danger', method: :post %></td>
+                    </tr>
+                </tbody>
+            </table>
+
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/views/event_applications/index.html.erb
+++ b/app/views/event_applications/index.html.erb
@@ -1,7 +1,16 @@
 <!-- This calculates the amount  of all applicants in order to display an even amount on each page -->
 
-<div class="page-header">
-  <h1 class="page-title">Applications</h1>
+<div class="row align-items-center">
+  <div class="page-header col-sm-4">
+      <h1 class="page-title">Event Applications</h1>
+  </div>
+  <div class="col text-right">
+    <% if current_user.is_admin? %>
+    <%= link_to application_mode_event_applications_path do %>
+      <span class="btn btn-primary"><i class="fe fe-settings"></i> Set Application Mode</span>
+    <% end %>
+    <% end %>
+  </div>
 </div>
 
 <div class="row">

--- a/app/views/shared/home_pages/_admin_view.html.erb
+++ b/app/views/shared/home_pages/_admin_view.html.erb
@@ -40,7 +40,7 @@
       </div>
     </div>
   <% end %>
-  <% if HackumassWeb::Application::APPLICATIONS_MODE == 'open' %>
+  <% if @event_application_mode == 'open' %>
     <div class="col-sm-6 col-lg-3">
       <div class="card p-3">
         <a href="#" class="text-inherit text-decoration-none">
@@ -171,7 +171,7 @@
 <div class="row">
   <div class="col-sm-12 col-lg-12">
     <div class="card">
-      <% if check_feature_flag?($Applications) and HackumassWeb::Application::APPLICATIONS_MODE == 'open' %>
+      <% if check_feature_flag?($Applications) and @event_application_mode == 'open' %>
         <div class="card-status bg-green"></div>
         <div class="card-header">
           <h3 class="card-title">Event Applications are <b>OPEN</b></h3>
@@ -180,7 +180,7 @@
           <p>Participants can currently register for the event.</p>
           <p>To close regular-round applications, set <code>applications.mode</code> to <code>waitlist</code> in hackathon.yml</p>
         </div>
-      <% elsif HackumassWeb::Application::APPLICATIONS_MODE == 'waitlist' %>
+      <% elsif @event_application_mode == 'waitlist' %>
         <div class="card-status bg-orange"></div>
         <div class="card-header">
           <h3 class="card-title">Event Applications are <b>WAITLISTED</b></h3>

--- a/app/views/shared/home_pages/_new_user_view.html.erb
+++ b/app/views/shared/home_pages/_new_user_view.html.erb
@@ -3,10 +3,10 @@
     <div class="card">
       <div class="card-status bg-warning"></div>
       <div class="card-body d-flex flex-column">
-        <% if check_feature_flag?($Applications) and HackumassWeb::Application::APPLICATIONS_MODE == 'open' %>
+        <% if check_feature_flag?($Applications) and @event_application_mode == 'open' %>
           <%= render file: HackumassWeb::Application::copy_for('shared/home_pages/new_user_applications_open') %>  
         <% else %>
-          <% if HackumassWeb::Application::APPLICATIONS_MODE == 'waitlist' %>
+          <% if @event_application_mode == 'waitlist' %>
             <%= render file: HackumassWeb::Application::copy_for('shared/home_pages/new_user_applications_waitlisted') %>  
           <% else %>
             <%= render file: HackumassWeb::Application::copy_for('shared/home_pages/new_user_applications_closed') %>  

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,7 +43,6 @@ module HackumassWeb
     DONOTREPLY = config["emails"]["donotreply"]
     CONTACT_EMAIL = config["emails"]["contact"]
     SLACK_SUBDOMAIN = config["slack"]["subdomain"]
-    APPLICATIONS_MODE = config["applications"]["mode"]
     CHECKIN_UNIVERSITY_EMAIL_SUFFIX = config["checkin"]["university_email_suffix"]
     CHECKIN_UNIVERSITY_NAME = config["checkin"]["university_name"]
     CHECKIN_UNIVERSITY_NAME_CHECKS = config["checkin"]["university_name_checks"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,8 @@ Rails.application.routes.draw do
         post 'unflag_application'
         post 'app_rsvp'
         get 'search'
+        get 'application_mode'
+        post 'set_application_mode'
 
         get :rsvp
         get :unrsvp

--- a/lib/tasks/feature_flags.rake
+++ b/lib/tasks/feature_flags.rake
@@ -2,9 +2,10 @@ namespace :feature_flags do
   desc "Accept or flag student applications"
   task load_flags: :environment do
 
-    feature_flag_names = ['event_applications', 'mentorship_requests', 'hardware', 'projects', 'project_submissions', 'check_in','prizes', 'events', 'judging']
-    display_names = { "event_applications" => "Applications", "mentorship_requests" => "Mentorship Requests", "hardware" => "Hardware Requests", "projects" => "Projects: View", "project_submissions" => "Projects: Create", "check_in" => "Check-Ins", "prizes" => "Prizes", "events" => "Schedule", "judging" => "Judging"}
+    feature_flag_names = ['event_applications', 'application_mode', 'mentorship_requests', 'hardware', 'projects', 'project_submissions', 'check_in','prizes', 'events', 'judging']
+    display_names = { "event_applications" => "Applications", "application_mode" => "Event Application Mode", "mentorship_requests" => "Mentorship Requests", "hardware" => "Hardware Requests", "projects" => "Projects: View", "project_submissions" => "Projects: Create", "check_in" => "Check-Ins", "prizes" => "Prizes", "events" => "Schedule", "judging" => "Judging"}
     description = { "event_applications" => "Enables hackers to start registering and applying to the hackathon", 
+      "application_mode" => "closed",
       "mentorship_requests" => "Allows hackers to request mentor help", 
       "hardware" => "Enables the ability for hackers to checkout hardware", 
       "projects" => "Allows projects to be seen to the public", 
@@ -26,7 +27,7 @@ namespace :feature_flags do
       puts "Updating #{flag_name} feature flag."
     end
 
-    puts 'All Feature flags created successfully!'
+    puts 'All Feature Flags Created Successfully!'
 
   end
 


### PR DESCRIPTION
PR closes #222

By creating a special feature flag, the current application status is stored and can be changed via a button in the top right of the event application page. Addressed minor bug. that allow users to apply when mode isn't set to open.

When changing the event application mode, user is brought to page with current mode and descriptions of what each mode will do. They can select an option and it will change in real-time.