### PR TITLE
Updated user.rb to deny non-UMass email users from both signing up or logging in

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   validates_presence_of :first_name, :last_name
+  # validate that a new user has @umass.edu email to sign up
+  validates_format_of :email, with: /\@umass\.edu/, message: 'must have domain @umass.edu to register on Dashboard!'
 
   if !Rails.env.development? && HackumassWeb::Application::EMAIL_VERIFICATION
     devise :database_authenticatable, :registerable,
@@ -33,6 +35,11 @@ class User < ApplicationRecord
 
   # slack workspace token for your hackathon
   $workspace_token = "#{HackumassWeb::Application::SLACK_WORKSPACE_TOKEN}"
+
+  # ensure that any users that already signed up with non-UMass emails cannot sign in any longer
+  def active_for_authentication?
+    super && email.include?(HackumassWeb::Application::CHECKIN_UNIVERSITY_EMAIL_SUFFIX)
+  end
 
   # Use type checkers
   def is_attendee?


### PR DESCRIPTION
This PR intends to fix #255, by verifying and validating emails during sign-up and login.

## Changelog
- Added email format validation for User class with regular expression `/\@umass\.edu/`. Will display error message "Email must have domain @umass.edu to register on Dashboard!" on UI when trying to sign-up with non-UMass emails
- Added email authentication for User class testing whether email follows suit with email suffix passed as parameter ("@umass.edu") here. Will display "You account is not activated yet." on UI when trying to log in with non-UMass emails registered before this PR was merged
- Tested that valid @umass.edu emails are still able to successfully sign up and log in

## Code Changes
- Denying users when trying to sign-up with non-UMass emails
```rb
+  # validate that a new user has @umass.edu email to sign up
+  validates_format_of :email, with: /\@umass\.edu/, message: 'must have domain @umass.edu to register on Dashboard!'
```
- Denying users when trying to log in with non-UMass emails already signed-up before this PR got merged
```rb
+  # ensure that any users that already signed up with non-UMass emails cannot sign in any longer
+  def active_for_authentication?
+    super && email.include?(HackumassWeb::Application::CHECKIN_UNIVERSITY_EMAIL_SUFFIX)
+  end
```

## User Testing
#### **Denying users when trying to sign-up with non-UMass emails**
![Deny Sign-Up](https://user-images.githubusercontent.com/20084950/138510351-1c2483a3-95c8-48d6-a80b-981cf908d216.png)

#### **Denying users when trying to log in with non-UMass emails already signed-up before this PR got merged**
![Deny Log-In](https://user-images.githubusercontent.com/20084950/138510364-526809a7-6a97-4101-9186-607bfb9afc44.png)

#### **Allowing users to sign up or log in (already existing) with UMass emails**
Please view this UI flow: https://youtu.be/-39pyyji52Y

## References
- [GitHub Devise Documentation for Validatable](https://github.com/heartcombo/devise/blob/main/lib/devise/models/validatable.rb)
- [Ruby Devise Documentation for Validatable](https://www.rubydoc.info/github/heartcombo/devise/master/Devise/Models/Validatable)
- [Ruby Devise Documentation for Authenticatable]( https://www.rubydoc.info/github/heartcombo/devise/master/Devise/Models/Authenticatable)