### PR TITLE
Update the Project Creation form to be consistent with new requirements (6th November 2021)

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,7 +3,7 @@ class Project < ApplicationRecord
 	before_create :rename_file
 	before_update :rename_file
 
-	validates_presence_of :title, :description, :inspiration, :does_what, :built_how, :challenges, :accomplishments, :learned, :next, :built_with, message: '%{attribute} can\'t be blank.'
+	validates_presence_of :title, :description, :youtube_link, :inspiration, :does_what, :built_how, :challenges, :accomplishments, :learned, :next, :built_with, message: '%{attribute} can\'t be blank.'
 	validates_uniqueness_of :title, message: '%{attribute} has already been taken.'
 
 	has_many :user
@@ -14,7 +14,13 @@ class Project < ApplicationRecord
 	has_attached_file :projectimage,
 										path: 'project/:filename'
 
-
+	# validates the format of the youtube_link (allowed to be blank so that it doesn't show 2 errors if absent as we're
+	# already validating its presence above) if it is indeed present because it needs to start with "https://"
+	validates :youtube_link,
+            allow_blank: true, 
+			if: -> { link.present? },
+            format: { with: /\G[hH][tT][tT][pP][sS]:\/\/.*/,
+                      message: 'YouTube link must begin with \'https://\'' }
 
 	validates :link,
             allow_blank: true,

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -171,10 +171,13 @@
     <div class='card'>
       <div class='card-body'>
         <h3>
-          For judging purposes, do you need a wall outlet?
+          For judging purposes, are you participating only virtually? Otherwise, leave blank.
         </h3>
+        <%# Note that the question now asks for confirmation of being a virtual participant and not the wall outlet requirement so %>
+        <%# while this may not be the best practice for long term development, I am leaving the form field as supplying the :power %>
+        <%# symbol in the interest of not wrangling with model changes and creating updated migrations in the middle of the event %>
         <%= form.check_box(:power)%>
-        <%= form.label :power,'Yes, I need an outlet to connect my project to.'%>
+        <%= form.label :power,'Yes, I am a virtual participant for HackUMass IX!'%>
       </div>
     </div>
 

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -77,8 +77,8 @@
       <h3>
         Do you have a YouTube video link?
       </h3>
-      <p style="color: grey; ">A project video is optional. <b>The video should be between 30 and 60 seconds long, and demonstrate how your hack works.</b> No PowerPoint slides, please. Cinema-level video editing not required.</p>
-      <%= form.text_field :youtube_link, id: :youtube_link, class: 'form-control', placeholder: "This is optional, but if you don't upload a video then please upload a photo!" %>
+      <p style="color: grey; "><b>A project video is required. The video should be between 2 - 3 minutes long, and demonstrate how your hack works.</b> No PowerPoint slides, please. Cinema-level video editing not required.</p>
+      <%= form.text_field :youtube_link, id: :youtube_link, class: 'form-control', placeholder: "Link us to your project's video demonstration!" %>
     </div>
 
     <div class="form-group">


### PR DESCRIPTION
This PR is intended to fix #260 as well as fix #261.

### Requirements
- Make video links mandatory in the Project Creation page
- Change functionality of wall outlet field in project creation form to verify whether the user is participating virtually

### Changelog
- Updated the Project model to validate the presence and format of YouTube link [validates the format of the youtube_link (allowed to be blank so that it doesn't show 2 errors if absent as we're already validating its presence above) if it is indeed present because it needs to start with `https://`]
- Updated the Project Creation view to be consistent with model changes and new requirements
- Updated the Project creation form view to have the checkbox for virtual participants [Note that the question now asks for confirmation of being a virtual participant and not the wall outlet requirement so while this may not be the best practice for long term development, I am leaving the form field as supplying the :power symbol in the interest of not wrangling with model changes and creating updated migrations in the middle of the event.]

### Individual Views

#### 
####

### Functionality Views/Demos

#### Before Project Submission View (with filled data)
![Pre-Submit](https://user-images.githubusercontent.com/20084950/140633434-a9cff56a-0463-457a-8e18-f3a9573afa35.png)
 
#### Absent `youtube_link` field Submission View (with filled data)
![Absent Field](https://user-images.githubusercontent.com/20084950/140633575-441c9e1d-65b1-4437-ab20-217151a90d83.png)

#### Incorrectly formatted `youtube_link` field Submission View (with filled data)
![Incorrect Format](https://user-images.githubusercontent.com/20084950/140633579-9390ab49-a852-4afa-a2c8-f548b2bdf58c.png)

#### Successful New Project Submission (with filled data)
https://user-images.githubusercontent.com/20084950/140633588-9b978766-7ce1-42bd-b2f4-43282e69e1d0.mov

#### Final Project Creation Form View
![Final View](https://user-images.githubusercontent.com/20084950/140633479-0e451745-9aec-475c-8094-4aeaf319d897.png)
