### PR TITLE
Fixed the event applications resume card height

### DIFF
--- a/app/assets/stylesheets/event_application.scss
+++ b/app/assets/stylesheets/event_application.scss
@@ -74,7 +74,6 @@ $error-color: red;
 
 .event-application-resume-container {
   width: 100%;
-  height: 80vh;
 }
 
 #javascript-container {


### PR DESCRIPTION
## Changelog
- Removed the CSS property responsible for excessive height of the resume panel

## View
![Screen Shot 2022-10-03 at 4 03 49 PM](https://user-images.githubusercontent.com/20084950/193668663-24e75de9-e431-4558-ac7d-aac1f232db38.png)
