### PR TITLE
312 local recaptcha error when signing up

### DIFF
--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,4 +1,10 @@
 Recaptcha.configure do |config|
-    config.site_key  = ENV['RECAPTCHA_SITE_KEY']
-    config.secret_key = ENV['RECAPTCHA_SECRET_KEY']
+    if ENV['RAILS_ENV'] == 'production'
+        config.site_key  = ENV['RECAPTCHA_SITE_KEY']
+        config.secret_key = ENV['RECAPTCHA_SECRET_KEY']
+    else
+        config.site_key = 'development_site_key'
+        config.secret_key = 'development_secret_key'
+        config.skip_verify_env << 'development'
+    end
 end

--- a/docker_shell.sh
+++ b/docker_shell.sh
@@ -1,6 +1,6 @@
 CURR_DIR="${PWD##*/}"
 
-RUNNING_ID="docker ps --format '{{.ID}}' -f 'ancestor=${CURR_DIR}_rails'"
+RUNNING_ID="docker ps --format '{{.ID}}' -f 'ancestor=${CURR_DIR}-rails'"
 if [[ "$RUNNING_ID" == "" ]]; then
     echo Running new container instance
     ./docker/docker_run.sh ${@:-/bin/bash}


### PR DESCRIPTION
1. `docker_shell.sh` should now be able to connect to running instance after fixing formatting issue in `RUNNING_ID`.
2. reCAPTCHA should not get initialized when running locally.

#312 