### PR TITLE
183 rename prize model fields

### DIFF
--- a/app/controllers/prizes_controller.rb
+++ b/app/controllers/prizes_controller.rb
@@ -50,7 +50,7 @@ class PrizesController < ApplicationController
     @project = nil
 
     Project.all.each do |p|
-      if p.prizes_won.include? @prize.criteria
+      if p.prizes_won.include? @prize.title
         @project = p
         break
       end
@@ -73,7 +73,7 @@ class PrizesController < ApplicationController
       return
     end
 
-    project.prizes_won << prize.criteria
+    project.prizes_won << prize.title
     project.save
 
     redirect_to prize_assign_path, notice: 'Successfully assigned winner to prize.'
@@ -93,7 +93,7 @@ class PrizesController < ApplicationController
       return
     end
     
-    project.prizes_won.delete(prize.criteria)
+    project.prizes_won.delete(prize.title)
     project.save
 
     redirect_to prize_assign_path, notice: 'Successfully removed prize from project.'
@@ -107,7 +107,7 @@ class PrizesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def prize_params
-      params.require(:prize).permit(:name, :description, :criteria, :sponsor, :priority, :project_selectable)
+      params.require(:prize).permit(:award, :description, :title, :sponsor, :priority, :project_selectable)
     end
 
     def check_permissions

--- a/app/models/prize.rb
+++ b/app/models/prize.rb
@@ -1,3 +1,4 @@
 class Prize < ApplicationRecord
-	validates_presence_of :name, :description, :criteria, :sponsor, :priority
+	validates_presence_of :award, :description, :title, :sponsor, :priority
 end
+ 

--- a/app/views/prizes/_form.html.erb
+++ b/app/views/prizes/_form.html.erb
@@ -18,18 +18,18 @@
   <% end %>
 
   <div class="form-group">
-    <%= form.label :name, class:'control-label' %>
-    <%= form.text_field :name, class: 'form-control', placeholder: 'Give it a name! Is this an Amazon Echo? A GTX 1080? ' %>
+    <%= form.label :award, class:'control-label' %>
+    <%= form.text_field :award, class: 'form-control', placeholder: 'Give it a award! Is this an Amazon Echo? A GTX 1080? ' %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :title, class:'control-label' %>
+    <%= form.text_area :title, class: 'form-control', placeholder: 'What do hackers need to do in order to win this prize? Use an API? Create a hack that helps people?' %>
   </div>
 
   <div class="form-group">
     <%= form.label :description, class:'control-label' %>
     <%= form.text_area :description, class: 'form-control', placeholder: 'Describe the prize. You can just google a description for the item and paste it here...' %>
-  </div>
-
-  <div class="form-group">
-    <%= form.label :criteria, class:'control-label' %>
-    <%= form.text_area :criteria, class: 'form-control', placeholder: 'What do hackers need to do in order to win this prize? Use an API? Create a hack that helps people?' %>
   </div>
 
   <div class="form-group">
@@ -50,7 +50,7 @@
   <div class="form-group">
     
     <%= form.check_box :project_selectable, {}, true %> <%= form.label :project_selectable, class:'control-label' %> <br>
-    If selected, teams will be able to note that they are submitting a project for this prize. The text in the Criteria field will be used for the prize category.
+    If selected, teams will be able to note that they are submitting a project for this prize. The text in the Title field will be used for the prize category.
   </div>
 
   <div class="actions">

--- a/app/views/prizes/assign.html.erb
+++ b/app/views/prizes/assign.html.erb
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1 class="page-title">Assign Prize Winner: <%= @prize.criteria.capitalize %></h1>
+  <h1 class="page-title">Assign Prize Winner: <%= @prize.title.capitalize %></h1>
 </div>
 
 <div class="row">

--- a/app/views/prizes/index.html.erb
+++ b/app/views/prizes/index.html.erb
@@ -24,13 +24,13 @@
   <% end %>
   <div class="card-header border-secondary">
     <% if current_user.is_organizer? %>
-      <h3 class="card-title"> <%= link_to prize.name, prize%> </h3>
+      <h3 class="card-title"> <%= link_to prize.award, prize%> </h3>
     <% else %>
-      <h3 class="card-title"> <%= prize.name %> </h3>
+      <h3 class="card-title"> <%= prize.award %> </h3>
     <% end %>
   </div>
   <div class="card-body">
-    <p> <b> Criteria: </b> <%= prize.criteria %> </p>
+    <p> <b> Title: </b> <%= prize.title %> </p>
     <p> <b> Description: </b> <%= prize.description %> </p>
     <p> <b> Sponsored by: </b> <%= prize.sponsor %> </p>
     <% if prize.project_selectable %>

--- a/app/views/prizes/show.html.erb
+++ b/app/views/prizes/show.html.erb
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1 class="page-title"><%= @prize.name %></h1>
+  <h1 class="page-title"><%= @prize.award %></h1>
 </div>
 
 <p id="notice"><%= notice %></p>
@@ -12,13 +12,13 @@
     </div>
     <div class="card-body">
       <p>
-        <strong>Description:</strong>
-        <%= @prize.description %>
+        <strong>Title:</strong>
+        <%= @prize.title %>
       </p>
 
       <p>
-        <strong>Criteria:</strong>
-        <%= @prize.criteria %>
+        <strong>Description:</strong>
+        <%= @prize.description %>
       </p>
 
       <p>

--- a/db/migrate/20231002032542_rename_prize_model_fields.rb
+++ b/db/migrate/20231002032542_rename_prize_model_fields.rb
@@ -1,0 +1,6 @@
+class RenamePrizeModelFields < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :prizes, :name, :award
+    rename_column :prizes, :criteria, :title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_09_013144) do
+ActiveRecord::Schema.define(version: 2023_10_02_032542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -171,9 +171,9 @@ ActiveRecord::Schema.define(version: 2022_11_09_013144) do
   end
 
   create_table "prizes", force: :cascade do |t|
-    t.string "name"
+    t.string "award"
     t.string "description"
-    t.string "criteria"
+    t.string "title"
     t.string "sponsor"
     t.integer "priority"
     t.datetime "created_at", null: false

--- a/test/controllers/prizes_controller_test.rb
+++ b/test/controllers/prizes_controller_test.rb
@@ -17,7 +17,7 @@ class PrizesControllerTest < ActionDispatch::IntegrationTest
 
   test "should create prize" do
     assert_difference('Prize.count') do
-      post prizes_url, params: { prize: { criteria: @prize.criteria, description: @prize.description, name: @prize.name, priority: @prize.priority, sponsor: @prize.sponsor } }
+      post prizes_url, params: { prize: { title: @prize.title, description: @prize.description, award: @prize.award, priority: @prize.priority, sponsor: @prize.sponsor } }
     end
 
     assert_redirected_to prize_url(Prize.last)
@@ -34,7 +34,7 @@ class PrizesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update prize" do
-    patch prize_url(@prize), params: { prize: { criteria: @prize.criteria, description: @prize.description, name: @prize.name, priority: @prize.priority, sponsor: @prize.sponsor } }
+    patch prize_url(@prize), params: { prize: { title: @prize.title, description: @prize.description, award: @prize.award, priority: @prize.priority, sponsor: @prize.sponsor } }
     assert_redirected_to prize_url(@prize)
   end
 

--- a/test/fixtures/prizes.yml
+++ b/test/fixtures/prizes.yml
@@ -1,15 +1,15 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  name: MyString
+  award: MyString
   description: MyString
-  criteria: MyString
+  title: MyString
   sponsor: MyString
   priority: 
 
 two:
-  name: MyString
+  award: MyString
   description: MyString
-  criteria: MyString
+  title: MyString
   sponsor: MyString
   priority: 

--- a/test/system/prizes_test.rb
+++ b/test/system/prizes_test.rb
@@ -14,9 +14,9 @@ class PrizesTest < ApplicationSystemTestCase
     visit prizes_url
     click_on "New Prize"
 
-    fill_in "Criteria", with: @prize.criteria
+    fill_in "Title", with: @prize.title
     fill_in "Description", with: @prize.description
-    fill_in "Name", with: @prize.name
+    fill_in "Award", with: @prize.award
     fill_in "Priority", with: @prize.priority
     fill_in "Sponsor", with: @prize.sponsor
     click_on "Create Prize"
@@ -29,9 +29,9 @@ class PrizesTest < ApplicationSystemTestCase
     visit prizes_url
     click_on "Edit", match: :first
 
-    fill_in "Criteria", with: @prize.criteria
+    fill_in "Title", with: @prize.title
     fill_in "Description", with: @prize.description
-    fill_in "Name", with: @prize.name
+    fill_in "Award", with: @prize.award
     fill_in "Priority", with: @prize.priority
     fill_in "Sponsor", with: @prize.sponsor
     click_on "Update Prize"


### PR DESCRIPTION
- Rename `name` to `award`, `criteria` to `title`.
- Add migration to reflect this change.
- Update this change to controller, templates, and tests

## Screenshots
![image](https://github.com/fuseumass/dashboard/assets/25674728/0689abf4-eb05-4be2-a314-1029910512ab)
![image](https://github.com/fuseumass/dashboard/assets/25674728/0f87845d-9791-4ac1-a5bd-1dd572d7d26e)
![image](https://github.com/fuseumass/dashboard/assets/25674728/a27ddf59-b4d0-473a-a8cf-0989a8ec0762)
